### PR TITLE
EP-33 create wallet app and passport for obtaining and sharing did

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@types/react": "18.2.13",
 		"@types/react-dom": "18.2.6",
 		"@web5/api": "^0.8.4",
+		"@web5/crypto": "^0.4.0",
 		"@web5/dids": "^0.4.1",
 		"@web5/identity-agent": "^0.2.6",
 		"autoprefixer": "10.4.14",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"@types/react": "18.2.13",
 		"@types/react-dom": "18.2.6",
 		"@web5/api": "^0.8.4",
+		"@web5/dids": "^0.4.1",
+		"@web5/identity-agent": "^0.2.6",
 		"autoprefixer": "10.4.14",
 		"copy-to-clipboard": "^3.3.3",
 		"crypto-browserify": "^3.12.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ const ROUTES = ["web5/todolist", "web5/todolist-shared", "web5/identity-agent"];
 
 export default function Page() {
 	return (
-		<BasePage title="Web5 POCs">
+		<BasePage title="Standalone Web5 POC Apps">
 			<VStack
 				divider={<StackDivider borderColor="gray.200" />}
 				spacing={4}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,26 @@
 "use client";
 
-import { Box } from "@chakra-ui/react";
+import { Link, StackDivider, VStack } from "@chakra-ui/react";
+import { BasePage } from "./shared/BasePage";
 
 // `app/page.tsx` is the UI for the `/` URL
 
-const ROUTES = ["/web5/todolist", "web5/todolist-shared"];
+const ROUTES = ["web5/todolist", "web5/todolist-shared", "web5/identity-agent"];
 
 export default function Page() {
 	return (
-		<>
-			<h1>Hello, Home page!</h1>
-			{ROUTES.map((route) => (
-				<Box key={route}>
-					<a href={route}>{route}</a>
-				</Box>
-			))}
-		</>
+		<BasePage title="Web5 POCs">
+			<VStack
+				divider={<StackDivider borderColor="gray.200" />}
+				spacing={4}
+				align="stretch"
+			>
+				{ROUTES.map((route) => (
+					<Link href={route} key={route}>
+						{route}
+					</Link>
+				))}
+			</VStack>
+		</BasePage>
 	);
 }

--- a/src/app/web5/identity-agent/[slug]/page.tsx
+++ b/src/app/web5/identity-agent/[slug]/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { BasePage } from "@/app/shared/BasePage";
+import { Web5Provider } from "../providers";
+import { Profile } from "../components/Profile";
+
+// `app/page.tsx` is the UI for the `/` URL
+
+export default function Page({ params }: { params: { slug: string } }) {
+	const did = params.slug ?? "";
+	return (
+		<BasePage title="Profile" description={`did: ${did}`}>
+			<Profile />
+		</BasePage>
+	);
+}

--- a/src/app/web5/identity-agent/[slug]/page.tsx
+++ b/src/app/web5/identity-agent/[slug]/page.tsx
@@ -10,7 +10,9 @@ export default function Page({ params }: { params: { slug: string } }) {
 	const did = params.slug ?? "";
 	return (
 		<BasePage title="Profile" description={`did: ${did}`}>
-			<Profile />
+			<Web5Provider did={did}>
+				<Profile />
+			</Web5Provider>
 		</BasePage>
 	);
 }

--- a/src/app/web5/identity-agent/components/Profile.tsx
+++ b/src/app/web5/identity-agent/components/Profile.tsx
@@ -1,0 +1,3 @@
+export const Profile = () => {
+	return <div>My Profile</div>;
+};

--- a/src/app/web5/identity-agent/components/Profiles.tsx
+++ b/src/app/web5/identity-agent/components/Profiles.tsx
@@ -1,3 +1,60 @@
+import { ActionableItem } from "@/app/shared/ActionableItem";
+import { BasePage } from "@/app/shared/BasePage";
+import { AddIcon } from "@chakra-ui/icons";
+import {
+	Box,
+	Heading,
+	IconButton,
+	Input,
+	StackDivider,
+	Text,
+	VStack,
+} from "@chakra-ui/react";
+import { useCallback, useState } from "react";
+import { useAgent } from "../providers/AgentProvider";
+
 export const Profiles = () => {
-	return <div>List of My Profiles</div>;
+	const [newName, setNewName] = useState("");
+
+	const { addIdentity, identities } = useAgent();
+	console.log("identities", identities);
+	const handleCreateNewIdentity = useCallback(() => {
+		console.log("creating new did with the name", newName);
+		addIdentity({ name: newName });
+	}, [newName, addIdentity]);
+
+	return (
+		<>
+			<ActionableItem
+				itemComponent={
+					<Input
+						placeholder="new DID name"
+						value={newName}
+						onChange={(event) => setNewName(event.target.value)}
+					/>
+				}
+				actionComp={
+					<IconButton
+						aria-label="add"
+						size="sm"
+						colorScheme="blue"
+						icon={<AddIcon />}
+						onClick={handleCreateNewIdentity}
+					/>
+				}
+			/>
+			<VStack
+				divider={<StackDivider borderColor="gray.200" />}
+				spacing={4}
+				align="stretch"
+			>
+				{identities.map((i) => (
+					<Box key={i.did}>
+						<Heading fontSize="m">{i.name}</Heading>
+						<Text mt={4}>{i.did}</Text>
+					</Box>
+				))}
+			</VStack>
+		</>
+	);
 };

--- a/src/app/web5/identity-agent/components/Profiles.tsx
+++ b/src/app/web5/identity-agent/components/Profiles.tsx
@@ -1,8 +1,10 @@
 import { ActionableItem } from "@/app/shared/ActionableItem";
+import { useRouter, usePathname } from "next/navigation";
 import { BasePage } from "@/app/shared/BasePage";
 import { AddIcon } from "@chakra-ui/icons";
 import {
 	Box,
+	Button,
 	Heading,
 	IconButton,
 	Input,
@@ -14,13 +16,17 @@ import { useCallback, useState } from "react";
 import { useAgent } from "../providers/AgentProvider";
 
 export const Profiles = () => {
+	const router = useRouter();
+	const pathname = usePathname();
 	const [newName, setNewName] = useState("");
 
 	const { addIdentity, identities } = useAgent();
+
 	console.log("identities", identities);
+
 	const handleCreateNewIdentity = useCallback(() => {
 		console.log("creating new did with the name", newName);
-		addIdentity({ name: newName });
+		addIdentity({ name: newName, onSuccess: () => setNewName("") });
 	}, [newName, addIdentity]);
 
 	return (
@@ -49,10 +55,25 @@ export const Profiles = () => {
 				align="stretch"
 			>
 				{identities.map((i) => (
-					<Box key={i.did}>
-						<Heading fontSize="m">{i.name}</Heading>
-						<Text mt={4}>{i.did}</Text>
-					</Box>
+					<ActionableItem
+						key={i.did}
+						itemComponent={
+							<Box w="85%">
+								<Heading fontSize="m">{i.name}</Heading>
+								<Text mt={4}>{i.did}</Text>
+							</Box>
+						}
+						actionComp={
+							<Button
+								ml="-60px"
+								onClick={() => {
+									router.push(`${pathname}/${i.did}`);
+								}}
+							>
+								Open
+							</Button>
+						}
+					/>
 				))}
 			</VStack>
 		</>

--- a/src/app/web5/identity-agent/components/Profiles.tsx
+++ b/src/app/web5/identity-agent/components/Profiles.tsx
@@ -1,0 +1,3 @@
+export const Profiles = () => {
+	return <div>List of My Profiles</div>;
+};

--- a/src/app/web5/identity-agent/components/Profiles.tsx
+++ b/src/app/web5/identity-agent/components/Profiles.tsx
@@ -1,10 +1,9 @@
 import { ActionableItem } from "@/app/shared/ActionableItem";
 import { useRouter, usePathname } from "next/navigation";
-import { BasePage } from "@/app/shared/BasePage";
-import { AddIcon } from "@chakra-ui/icons";
+import { AddIcon, DownloadIcon, ViewIcon } from "@chakra-ui/icons";
 import {
 	Box,
-	Button,
+	HStack,
 	Heading,
 	IconButton,
 	Input,
@@ -20,9 +19,7 @@ export const Profiles = () => {
 	const pathname = usePathname();
 	const [newName, setNewName] = useState("");
 
-	const { addIdentity, identities } = useAgent();
-
-	console.log("identities", identities);
+	const { addIdentity, keyManager, identities } = useAgent();
 
 	const handleCreateNewIdentity = useCallback(() => {
 		console.log("creating new did with the name", newName);
@@ -60,18 +57,34 @@ export const Profiles = () => {
 						itemComponent={
 							<Box w="85%">
 								<Heading fontSize="m">{i.name}</Heading>
-								<Text mt={4}>{i.did}</Text>
+								<Text maxW="100%" isTruncated mt={4}>
+									{i.did}
+								</Text>
 							</Box>
 						}
 						actionComp={
-							<Button
-								ml="-60px"
-								onClick={() => {
-									router.push(`${pathname}/${i.did}`);
-								}}
-							>
-								Open
-							</Button>
+							<HStack ml="-60px">
+								<IconButton
+									aria-label="view"
+									size="sm"
+									icon={<ViewIcon />}
+									onClick={() => {
+										router.push(`${pathname}/${i.did}`);
+									}}
+								/>
+								<IconButton
+									aria-label="download"
+									size="sm"
+									icon={<DownloadIcon />}
+									onClick={async () => {
+										console.log("keyUri", i.keyUri);
+										const secretKey = await keyManager?.exportKey({
+											keyUri: i.keyUri,
+										});
+										console.log("exporting secretKey", secretKey);
+									}}
+								/>
+							</HStack>
 						}
 					/>
 				))}

--- a/src/app/web5/identity-agent/components/Profiles.tsx
+++ b/src/app/web5/identity-agent/components/Profiles.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useState } from "react";
 import { useAgent } from "../providers/AgentProvider";
+import { getDidDocument } from "../providers/AgentProvider/utils";
 
 export const Profiles = () => {
 	const router = useRouter();
@@ -69,7 +70,10 @@ export const Profiles = () => {
 									size="sm"
 									icon={<ViewIcon />}
 									onClick={() => {
-										router.push(`${pathname}/${i.did}`);
+										// call a util function to retrieve DidDocument
+										getDidDocument({ did: i.did });
+
+										// router.push(`${pathname}/${i.did}`);
 									}}
 								/>
 								<IconButton

--- a/src/app/web5/identity-agent/page.tsx
+++ b/src/app/web5/identity-agent/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BasePage } from "@/app/shared/BasePage";
+
+// import { getData } from "./components/utils";
+import { Web5Provider } from "./providers";
+import { Profiles } from "./components/Profiles";
+
+// `app/page.tsx` is the UI for the `/` URL
+
+const PAGE_DESCRIPTION =
+	"Create new DID, manage profiles, and grant other apps access to DID profiles";
+
+export default function Page() {
+	return (
+		// <Web5Provider>
+		<BasePage title="Profile" description={PAGE_DESCRIPTION}>
+			<Profiles />
+		</BasePage>
+		// </Web5Provider>
+	);
+}

--- a/src/app/web5/identity-agent/page.tsx
+++ b/src/app/web5/identity-agent/page.tsx
@@ -1,23 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { BasePage } from "@/app/shared/BasePage";
 
-// import { getData } from "./components/utils";
-import { Web5Provider } from "./providers";
 import { Profiles } from "./components/Profiles";
+import { AgentProvider } from "./providers/AgentProvider";
 
 // `app/page.tsx` is the UI for the `/` URL
 
 const PAGE_DESCRIPTION =
-	"Create new DID, manage profiles, and grant other apps access to DID profiles";
+	"Create new identity agent to create new DIDs and view existing DIDs.";
 
 export default function Page() {
 	return (
-		// <Web5Provider>
-		<BasePage title="Profile" description={PAGE_DESCRIPTION}>
-			<Profiles />
-		</BasePage>
-		// </Web5Provider>
+		<AgentProvider>
+			<BasePage title="Identity Agent" description={PAGE_DESCRIPTION}>
+				<Profiles />
+			</BasePage>
+		</AgentProvider>
 	);
 }

--- a/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
+++ b/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
@@ -12,7 +12,7 @@ import { createAgent, genCreateIdentity } from "./utils";
 interface AgentContextState {
 	agent: any;
 	identities: any[];
-	addIdentity: (args: { name: string }) => void;
+	addIdentity: (args: { name: string; onSuccess: () => void }) => void;
 }
 
 const AgentContext = createContext<AgentContextState>({
@@ -23,7 +23,11 @@ const AgentContext = createContext<AgentContextState>({
 
 export const AgentProvider = ({ children }: { children: React.ReactNode }) => {
 	const [agent, setAgent] = useState<IdentityAgent | null>(null);
-	const [identities, setIdentities] = useState<any[]>([]);
+	const [identities, setIdentities] = useState<any[]>([
+		// TODO: temp for testing. Remove after identity agent works
+		{ name: "Default", did: "did:web5:default" },
+		{ name: "Default2", did: "did:web5:default2" },
+	]);
 
 	useEffect(() => {
 		createAgent({
@@ -37,12 +41,13 @@ export const AgentProvider = ({ children }: { children: React.ReactNode }) => {
 	const createIdentity = useMemo(() => genCreateIdentity(agent), [agent]);
 
 	const addIdentity = useCallback(
-		({ name }: { name: string }) => {
+		({ name, onSuccess }: { name: string; onSuccess: () => void }) => {
 			createIdentity({
 				name,
 				onSuccess: ({ did }) => {
 					console.log("identity created", did);
 					setIdentities((prev) => [...prev, { name, did }]);
+					onSuccess();
 				},
 			});
 		},

--- a/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
+++ b/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
@@ -1,0 +1,72 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
+import { IdentityAgent } from "@web5/identity-agent";
+import { createAgent, genCreateIdentity } from "./utils";
+
+interface AgentContextState {
+	agent: any;
+	identities: any[];
+	addIdentity: (args: { name: string }) => void;
+}
+
+const AgentContext = createContext<AgentContextState>({
+	agent: null,
+	identities: [],
+	addIdentity: (args: { name: string }) => {},
+});
+
+export const AgentProvider = ({ children }: { children: React.ReactNode }) => {
+	const [agent, setAgent] = useState<IdentityAgent | null>(null);
+	const [identities, setIdentities] = useState<any[]>([]);
+
+	useEffect(() => {
+		createAgent({
+			onSuccess: ({ agent }: { agent: IdentityAgent }) => {
+				console.log("agent created", agent);
+				setAgent(agent);
+			},
+		});
+	}, []);
+
+	const createIdentity = useMemo(() => genCreateIdentity(agent), [agent]);
+
+	const addIdentity = useCallback(
+		({ name }: { name: string }) => {
+			createIdentity({
+				name,
+				onSuccess: ({ did }) => {
+					console.log("identity created", did);
+					setIdentities((prev) => [...prev, { name, did }]);
+				},
+			});
+		},
+		[createIdentity],
+	);
+
+	const value = useMemo(
+		() => ({
+			agent,
+			identities,
+			addIdentity,
+		}),
+		[agent, identities, addIdentity],
+	);
+
+	return (
+		<AgentContext.Provider value={value}>{children}</AgentContext.Provider>
+	);
+};
+
+export const useAgent = () => {
+	const context = useContext(AgentContext);
+	if (!context) {
+		throw new Error("useAgent must be used within a AgentProvider");
+	}
+	return context;
+};

--- a/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
+++ b/src/app/web5/identity-agent/providers/AgentProvider/index.tsx
@@ -17,6 +17,12 @@ interface AgentContextState {
 	addIdentity: (args: { name: string; onSuccess: () => void }) => void;
 }
 
+interface Identity {
+	name: string;
+	did: string;
+	keyUri: string;
+}
+
 const AgentContext = createContext<AgentContextState>({
 	agent: null,
 	keyManager: null,
@@ -28,11 +34,7 @@ export const AgentProvider = ({ children }: { children: React.ReactNode }) => {
 	const [agent, setAgent] = useState<IdentityAgent | null>(null);
 	const [keyManager, setKeyManager] = useState<LocalKeyManager | null>(null);
 
-	const [identities, setIdentities] = useState<any[]>([
-		// TODO: temp for testing. Remove after identity agent works
-		{ name: "Default", did: "did:web5:default" },
-		{ name: "Default2", did: "did:web5:default2" },
-	]);
+	const [identities, setIdentities] = useState<Identity[]>([]);
 
 	useEffect(() => {
 		createAgent({

--- a/src/app/web5/identity-agent/providers/AgentProvider/utils.ts
+++ b/src/app/web5/identity-agent/providers/AgentProvider/utils.ts
@@ -46,3 +46,9 @@ export const genCreateIdentity =
 			onSuccess({ did, keyUri });
 		}
 	};
+
+export const getDidDocument = async ({ did }: { did: string }) => {
+	const resolution = await DidDht.resolve(did);
+	console.log("....resolution", resolution);
+	return resolution.didDocument;
+};

--- a/src/app/web5/identity-agent/providers/AgentProvider/utils.ts
+++ b/src/app/web5/identity-agent/providers/AgentProvider/utils.ts
@@ -1,0 +1,36 @@
+import { IdentityAgent } from "@web5/identity-agent";
+import { DidDht } from "@web5/dids";
+
+export const createAgent = async ({ onSuccess }) => {
+	const agent = await IdentityAgent.create();
+	if (agent) {
+		onSuccess({ agent });
+		return;
+	}
+	console.error("Failed to create identity agent");
+};
+
+export const genCreateIdentity =
+	(agent: IdentityAgent) =>
+	async ({ name, onSuccess }) => {
+		if (!agent) return;
+		// Creates a DID using the DHT method and publishes the DID Document to the DHT
+		const didDht = await DidDht.create();
+		const portableDid = await didDht.export();
+		const didDocument = JSON.stringify(didDht.document);
+
+		// DID string
+		const did = didDht.uri;
+
+		// Doesn't work because https://github.com/TBD54566975/web5-js/issues/440
+		// create managed identity
+		// const identity = await agent.identityManager.create({
+		// 	name,
+		// 	kms: "local",
+		// 	did: portableDid as any,
+		// });
+
+		console.log(".....portableDid", portableDid);
+		console.log(".....didDocument", didDocument);
+		onSuccess({ did });
+	};

--- a/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
+++ b/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
@@ -24,6 +24,7 @@ const Web5Context = createContext<Web5ContextState>({
 export const Web5Provider = ({
 	children,
 	protocolDefinition,
+	connectedDid,
 }: {
 	children: React.ReactNode;
 	protocolDefinition: unknown;

--- a/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
+++ b/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
@@ -7,56 +7,41 @@ import {
 	useState,
 } from "react";
 import { Web5 } from "@web5/api";
-import { configureProtocol, initDWN } from "./utils";
+import { initDWN } from "./utils";
 
 interface Web5ContextState {
 	web5: any;
-	did: string;
-	updateProtocol: (protocolDefinition: any) => void;
 }
 
 const Web5Context = createContext<Web5ContextState>({
-	did: "",
-	web5: [],
-	updateProtocol: () => {},
+	web5: null,
 });
 
 export const Web5Provider = ({
 	children,
-	protocolDefinition,
-	connectedDid,
+	did,
 }: {
 	children: React.ReactNode;
-	protocolDefinition: unknown;
+	did: string;
 }) => {
 	const [web5, setWeb5] = useState<Web5 | null>(null);
-	const [did, setDID] = useState("");
 
 	useEffect(() => {
+		console.log(".....web5Provider: did", did);
 		// create DID and Web5 instance
 		initDWN({
-			onSuccess: ({ web5, did }: { web5: Web5; did: string }) => {
+			connectedDid: did,
+			onSuccess: ({ web5 }: { web5: Web5; did: string }) => {
 				setWeb5(web5);
-				setDID(did);
-				configureProtocol({ web5, did, protocolDefinition });
 			},
 		});
-	}, [protocolDefinition]);
-
-	const updateProtocol = useCallback(
-		(protocolDefinition: unknown) => {
-			configureProtocol({ web5, did, protocolDefinition });
-		},
-		[web5, did],
-	);
+	}, [did]);
 
 	const value = useMemo(
 		() => ({
-			did,
 			web5,
-			updateProtocol,
 		}),
-		[did, web5, updateProtocol],
+		[web5],
 	);
 
 	return <Web5Context.Provider value={value}>{children}</Web5Context.Provider>;
@@ -65,7 +50,7 @@ export const Web5Provider = ({
 export const useWeb5 = () => {
 	const context = useContext(Web5Context);
 	if (!context) {
-		throw new Error("useTodoListManager must be used within a Web5Provider");
+		throw new Error("useWeb5 must be used within a Web5Provider");
 	}
 	return context;
 };

--- a/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
+++ b/src/app/web5/identity-agent/providers/Web5Provider/index.tsx
@@ -1,3 +1,5 @@
+import { IdentityAgent } from "@web5/identity-agent";
+import { Web5 } from "@web5/api";
 import {
 	createContext,
 	useCallback,
@@ -6,7 +8,6 @@ import {
 	useMemo,
 	useState,
 } from "react";
-import { Web5 } from "@web5/api";
 import { initDWN } from "./utils";
 
 interface Web5ContextState {
@@ -20,9 +21,11 @@ const Web5Context = createContext<Web5ContextState>({
 export const Web5Provider = ({
 	children,
 	did,
+	agent,
 }: {
 	children: React.ReactNode;
 	did: string;
+	agent: IdentityAgent;
 }) => {
 	const [web5, setWeb5] = useState<Web5 | null>(null);
 
@@ -30,6 +33,7 @@ export const Web5Provider = ({
 		console.log(".....web5Provider: did", did);
 		// create DID and Web5 instance
 		initDWN({
+			agent,
 			connectedDid: did,
 			onSuccess: ({ web5 }: { web5: Web5; did: string }) => {
 				setWeb5(web5);

--- a/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
+++ b/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
@@ -1,0 +1,55 @@
+import { Web5 } from "@web5/api";
+
+// checks if the protocol is installed and installs it if it isn't
+export const configureProtocol = async ({ web5, did, protocolDefinition }) => {
+	// query the list of existing protocols on the DWN
+	const { protocols, status } = await web5.dwn.protocols.query({
+		message: {
+			filter: {
+				protocol: protocolDefinition.protocol,
+			},
+		},
+	});
+
+	if (status.code !== 200) {
+		alert("Error querying protocols");
+		console.error("Error querying protocols", status);
+		return;
+	}
+
+	// if the protocol already exists, we return
+	if (protocols.length > 0) {
+		console.log("Protocol already exists");
+		return;
+	}
+
+	// configure protocol on local DWN
+	const { status: configureStatus, protocol } =
+		await web5.dwn.protocols.configure({
+			message: {
+				definition: protocolDefinition,
+			},
+		});
+
+	// sends the protocol configuration to the user's other DWeb Nodes
+	protocol.send(did);
+
+	console.log("Protocol configured", configureStatus, protocol);
+};
+
+export const initDWN = async ({ onSuccess }) => {
+	const { web5, did } = await Web5.connect();
+	if (web5 && did) {
+		onSuccess({ web5, did });
+		return;
+	}
+	console.error("Failed to connect to DWN");
+};
+
+// Not used but can be useful
+export const getDidDocument = async ({ web5, did }) => {
+	const resolution = await web5.did.resolve(did);
+	const didDocument = resolution.didDocument;
+	// console.log("didDocument", didDocument);
+	return didDocument;
+};

--- a/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
+++ b/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
@@ -1,46 +1,14 @@
 import { Web5 } from "@web5/api";
 
-// checks if the protocol is installed and installs it if it isn't
-export const configureProtocol = async ({ web5, did, protocolDefinition }) => {
-	// query the list of existing protocols on the DWN
-	const { protocols, status } = await web5.dwn.protocols.query({
-		message: {
-			filter: {
-				protocol: protocolDefinition.protocol,
-			},
-		},
-	});
+const TEST_DID = "did:dht:u1ehqfo7jpryedm7rqxyazh51pao4cz9xo7nuwohc77bumx49zdo";
 
-	if (status.code !== 200) {
-		alert("Error querying protocols");
-		console.error("Error querying protocols", status);
-		return;
-	}
-
-	// if the protocol already exists, we return
-	if (protocols.length > 0) {
-		console.log("Protocol already exists");
-		return;
-	}
-
-	// configure protocol on local DWN
-	const { status: configureStatus, protocol } =
-		await web5.dwn.protocols.configure({
-			message: {
-				definition: protocolDefinition,
-			},
-		});
-
-	// sends the protocol configuration to the user's other DWeb Nodes
-	protocol.send(did);
-
-	console.log("Protocol configured", configureStatus, protocol);
-};
-
-export const initDWN = async ({ onSuccess }) => {
-	const { web5, did } = await Web5.connect();
-	if (web5 && did) {
-		onSuccess({ web5, did });
+// TODO: must pass both agent and connectedDid to Web5.connect
+export const initDWN = async ({ connectedDid, onSuccess }) => {
+	const { web5, did } = await Web5.connect({ connectedDid: TEST_DID });
+	// unless you pass the agent, the web5 connect will always bootstrap a new did
+	console.log("web5, did", web5, did);
+	if (web5) {
+		onSuccess({ web5 });
 		return;
 	}
 	console.error("Failed to connect to DWN");

--- a/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
+++ b/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
@@ -22,11 +22,3 @@ export const initDWN = async ({
 	}
 	console.error("Failed to connect to DWN");
 };
-
-// Not used but can be useful
-export const getDidDocument = async ({ web5, did }) => {
-	const resolution = await web5.did.resolve(did);
-	const didDocument = resolution.didDocument;
-	// console.log("didDocument", didDocument);
-	return didDocument;
-};

--- a/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
+++ b/src/app/web5/identity-agent/providers/Web5Provider/utils.ts
@@ -1,10 +1,19 @@
 import { Web5 } from "@web5/api";
+import { IdentityAgent } from "@web5/identity-agent";
 
 const TEST_DID = "did:dht:u1ehqfo7jpryedm7rqxyazh51pao4cz9xo7nuwohc77bumx49zdo";
 
 // TODO: must pass both agent and connectedDid to Web5.connect
-export const initDWN = async ({ connectedDid, onSuccess }) => {
-	const { web5, did } = await Web5.connect({ connectedDid: TEST_DID });
+export const initDWN = async ({
+	agent,
+	connectedDid,
+	onSuccess,
+}: {
+	agent: IdentityAgent;
+	connectedDid: string;
+	onSuccess: ({ web5 }: { web5: Web5 }) => void;
+}) => {
+	const { web5, did } = await Web5.connect({ agent, connectedDid: TEST_DID });
 	// unless you pass the agent, the web5 connect will always bootstrap a new did
 	console.log("web5, did", web5, did);
 	if (web5) {

--- a/src/app/web5/identity-agent/providers/index.ts
+++ b/src/app/web5/identity-agent/providers/index.ts
@@ -1,0 +1,1 @@
+export { Web5Provider } from "./Web5Provider";

--- a/src/app/web5/todolist-shared/components/List.tsx
+++ b/src/app/web5/todolist-shared/components/List.tsx
@@ -75,7 +75,7 @@ export const List = () => {
 				}
 				actionComp={
 					<IconButton
-						aria-label="delete"
+						aria-label="add"
 						size="sm"
 						colorScheme="blue"
 						icon={<AddIcon />}

--- a/src/app/web5/todolist-shared/components/NewListCreator.tsx
+++ b/src/app/web5/todolist-shared/components/NewListCreator.tsx
@@ -52,7 +52,7 @@ export const NewListCreator = ({ createList }) => {
 				}
 				actionComp={
 					<IconButton
-						aria-label="delete"
+						aria-label="add"
 						size="sm"
 						colorScheme="blue"
 						icon={<AddIcon />}

--- a/src/app/web5/todolist-shared/providers/ListProvider/index.tsx
+++ b/src/app/web5/todolist-shared/providers/ListProvider/index.tsx
@@ -188,7 +188,7 @@ export const ListProvider = ({ children, protocolDefinition, listId }: any) => {
 export const useList = () => {
 	const context = useContext(TodoContext);
 	if (!context) {
-		throw new Error("useTodoListManager must be used within a Web5Provider");
+		throw new Error("useList must be used within a ListProvider");
 	}
 	return context;
 };

--- a/src/app/web5/todolist-shared/providers/Web5Provider/index.tsx
+++ b/src/app/web5/todolist-shared/providers/Web5Provider/index.tsx
@@ -17,7 +17,7 @@ interface Web5ContextState {
 
 const Web5Context = createContext<Web5ContextState>({
 	did: "",
-	web5: [],
+	web5: null,
 	updateProtocol: () => {},
 });
 

--- a/src/app/web5/todolist-shared/providers/Web5Provider/index.tsx
+++ b/src/app/web5/todolist-shared/providers/Web5Provider/index.tsx
@@ -64,7 +64,7 @@ export const Web5Provider = ({
 export const useWeb5 = () => {
 	const context = useContext(Web5Context);
 	if (!context) {
-		throw new Error("useTodoListManager must be used within a Web5Provider");
+		throw new Error("useWeb5 must be used within a Web5Provider");
 	}
 	return context;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,7 +1614,7 @@
     "@noble/hashes" "1.3.1"
     "@web5/common" "0.2.1"
 
-"@web5/crypto@0.4.0":
+"@web5/crypto@0.4.0", "@web5/crypto@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@web5/crypto/-/crypto-0.4.0.tgz#b77ca00e42fa432fde5e798492c9369acaf3a88d"
   integrity sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,14 @@
     multihashes "^4.0.3"
     uri-js "^4.4.1"
 
+"@dnsquery/dns-packet@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz#3abf2c7ebb6dece40a75f429e24f9de23671058a"
+  integrity sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==
+  dependencies:
+    "@leichtgewicht/ip-codec" "^2.0.4"
+    utf8-codec "^1.0.0"
+
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
@@ -1164,7 +1172,7 @@
     jsbi "^4.3.0"
     tslib "^2.4.1"
 
-"@leichtgewicht/ip-codec@^2.0.1":
+"@leichtgewicht/ip-codec@^2.0.1", "@leichtgewicht/ip-codec@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
@@ -1244,6 +1252,11 @@
   resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.1.4.tgz#96327dca147829ed9eee0d96cfdf7c57915765f0"
   integrity sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==
 
+"@noble/ciphers@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.4.1.tgz#977fc35f563a4ca315ebbc4cbb1f9b670bd54456"
+  integrity sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==
+
 "@noble/ciphers@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-0.3.0.tgz#6ba3090afdc7a7051393486f6af210e62e0f04ec"
@@ -1256,7 +1269,7 @@
   dependencies:
     "@noble/hashes" "1.3.1"
 
-"@noble/curves@^1.2.0":
+"@noble/curves@1.3.0", "@noble/curves@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
   integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
@@ -1535,6 +1548,20 @@
     readable-stream "4.4.2"
     readable-web-to-node-stream "3.0.2"
 
+"@web5/agent@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@web5/agent/-/agent-0.2.6.tgz#50d12bc6e10fe9a163c3714bd189b6660ed67568"
+  integrity sha512-qBbFH7b08Sw8JCpPQ+ClbblL++hkSR25e1XNF46ToVTJJldLspLTcXjr2Oui1bpJZ3jppnZ9nvcQPfymtdM5fg==
+  dependencies:
+    "@tbd54566975/dwn-sdk-js" "0.2.10"
+    "@web5/common" "0.2.3"
+    "@web5/crypto" "0.2.2"
+    "@web5/dids" "0.2.4"
+    level "8.0.0"
+    readable-stream "4.4.2"
+    readable-web-to-node-stream "3.0.2"
+    ulidx "2.1.0"
+
 "@web5/api@^0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4.tgz#b78ea5b54b44345764db87b64a8f552e68514468"
@@ -1568,6 +1595,15 @@
     multiformats "11.0.2"
     readable-stream "4.4.2"
 
+"@web5/common@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@web5/common/-/common-0.2.3.tgz#e6d238c3dbcae7a187a8ae41fe07762d50c6513c"
+  integrity sha512-WTbIS6l5inrQTS5cwOoQP5KEuUHZqOWCKCDAA62qGUn4QyySolog9Gt2HCNUEClIzzk/d5DHcpBgLCadHoJ6rQ==
+  dependencies:
+    level "8.0.0"
+    multiformats "11.0.2"
+    readable-stream "4.4.2"
+
 "@web5/crypto@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@web5/crypto/-/crypto-0.2.2.tgz#9f1fb1825203f91f75f85e6c4f3d90f3e8cd3726"
@@ -1577,6 +1613,16 @@
     "@noble/curves" "1.1.0"
     "@noble/hashes" "1.3.1"
     "@web5/common" "0.2.1"
+
+"@web5/crypto@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@web5/crypto/-/crypto-0.4.0.tgz#b77ca00e42fa432fde5e798492c9369acaf3a88d"
+  integrity sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==
+  dependencies:
+    "@noble/ciphers" "0.4.1"
+    "@noble/curves" "1.3.0"
+    "@noble/hashes" "1.3.3"
+    "@web5/common" "0.2.3"
 
 "@web5/dids@0.2.3":
   version "0.2.3"
@@ -1609,6 +1655,29 @@
     ms "2.1.3"
     pkarr "1.1.1"
     z32 "1.0.1"
+
+"@web5/dids@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.4.1.tgz#2767f7e5a15822818891294fe4c8cd91b20dc58e"
+  integrity sha512-EY55euXdDfdFMef2k8DeOrGmStBRhwvoai/JuJbUdCGDpvgwdoZWXPkGEkFr4VZQsfR7R7rNFMlsYw3VRPUVJw==
+  dependencies:
+    "@decentralized-identity/ion-sdk" "1.0.1"
+    "@dnsquery/dns-packet" "6.1.1"
+    "@web5/common" "0.2.3"
+    "@web5/crypto" "0.4.0"
+    bencode "4.0.0"
+    level "8.0.0"
+    ms "2.1.3"
+
+"@web5/identity-agent@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@web5/identity-agent/-/identity-agent-0.2.6.tgz#a42008eed2942af389170b5b7cabb0842a954608"
+  integrity sha512-DLkNZ6Q854ItkLErRMoeQ6cSAohATNYGvq8H0XSmJVFlhuNaedQdu+2xul2anW9Atm+WPzlBYeh5XAkFiHCBxg==
+  dependencies:
+    "@web5/agent" "0.2.6"
+    "@web5/common" "0.2.3"
+    "@web5/crypto" "0.2.2"
+    "@web5/dids" "0.2.4"
 
 "@web5/user-agent@0.2.5":
   version "0.2.5"
@@ -2012,6 +2081,13 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bencode@4.0.0, bencode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bencode/-/bencode-4.0.0.tgz#36ca0bc366290dad002215fc52fc74edf4eb0625"
+  integrity sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==
+  dependencies:
+    uint8-util "^2.2.2"
+
 bencode@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/bencode/-/bencode-2.0.3.tgz#89b9c80ea1b8573554915a7d0c15f62b0aa7fc52"
@@ -2023,13 +2099,6 @@ bencode@^3.0.3:
   integrity sha512-btsxX9201yoWh45TdqYg6+OZ5O1xTYKTYSGvJndICDFtznE/9zXgow8yjMvvhOqKKuzuL7h+iiCMpfkG8+QuBA==
   dependencies:
     uint8-util "^2.1.6"
-
-bencode@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bencode/-/bencode-4.0.0.tgz#36ca0bc366290dad002215fc52fc74edf4eb0625"
-  integrity sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==
-  dependencies:
-    uint8-util "^2.2.2"
 
 big-integer@^1.6.44:
   version "1.6.51"
@@ -5368,6 +5437,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+utf8-codec@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/utf8-codec/-/utf8-codec-1.0.0.tgz#b30252507271cd612dbf5b58f04620a5e1e7bb89"
+  integrity sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This POC demonstrates the use of a wallet to manage multiple DIDs. Specifically,
- The use of `DidDht` to create a new identity and
- The use of an `IdentityAgent` to manage a list of identities (blocked by pending TBD work)

As a workaround, the identity agent app instantiates its own `LocalKeyManager` which is passed to `DidDht`. When `DidDht` is called to create a new did, `LocalKeyManager` store gets populated with the private key associated with the newly created did.

There's no persistence for the private keys or dids. When TBD updates its `agent` libraries, we should get persistence and key management for free.

UIs are added to log to console the Did document and the private key for every created Did.

## Demo
https://youtu.be/VRFyg9qv3aA
